### PR TITLE
cookbook_fix

### DIFF
--- a/python/observability-online-eval/openai/computer-use/main.ipynb
+++ b/python/observability-online-eval/openai/computer-use/main.ipynb
@@ -378,8 +378,7 @@
     "    await handle(messages)\n",
     "\n",
     "# Run the example\n",
-    "import asyncio\n",
-    "asyncio.run(main())\n"
+    "await main()\n"
    ]
   },
   {


### PR DESCRIPTION
### TL;DR

Replace `asyncio.run(main())` with direct `await main()` call in the notebook.

### What changed?

Modified the way the main async function is executed in the notebook. Instead of using `asyncio.run(main())`, the code now directly uses `await main()`. This removes the unnecessary import of the asyncio module for this specific call.

### How to test?

1. Open the notebook `python/observability-online-eval/openai/computer-use/main.ipynb`
2. Run the cell containing the main function execution
3. Verify that the notebook executes correctly with the direct await syntax

### Why make this change?

In Jupyter notebooks, top-level await is supported, making the explicit `asyncio.run()` call unnecessary. This change simplifies the code by removing the redundant import and using the more direct approach for executing async functions in notebook environments.